### PR TITLE
Fixes issue with get_iOS_files when no xml file

### DIFF
--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -44,7 +44,6 @@ def image_file_to_xml_file(image_file):
 def get_phone_model(image_file):
     xml_file = image_file_to_xml_file(image_file)
     xml_dict = xml_to_dict(xml_file)
-    print(xml_dict['Model'])
 
     return xml_dict['Model']
 

--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -44,6 +44,7 @@ def image_file_to_xml_file(image_file):
 def get_phone_model(image_file):
     xml_file = image_file_to_xml_file(image_file)
     xml_dict = xml_to_dict(xml_file)
+    print(xml_dict['Model'])
 
     return xml_dict['Model']
 
@@ -125,13 +126,20 @@ def get_iOS_files(start_date=None, end_date=None, data_dir='/net/deco/iOSdata',
         file_list = [f for f in file_list if 'minBias' in f]
 
     # If specified, only keep files with desired phone model(s)
-    if phone_model:
+    if phone_model is not None:
         # Validate phone_model input
         if isinstance(phone_model, str):
             phone_model_list = [phone_model]
         assert isinstance(phone_model_list, (list, tuple, np.ndarray))
 
-        file_list = [f for f in file_list if get_phone_model(f) in phone_model_list]
+        filtered_list = []
+        # Filter out non-matching phone models
+        for idx, f in enumerate(file_list):
+            try:
+                if get_phone_model(f) in phone_model_list: filtered_list.append(f)
+            except:
+                continue
+        file_list = filtered_list
 
     # Cast file_list from a python list to a numpy.ndarray
     file_array = np.asarray(file_list, dtype=str)


### PR DESCRIPTION
Now, if no phone model is specified, then all image files
are returned. If a phone model is specified, and no
corresponding xml file exists for an image, then the image
file is not included. 


See issue #5