### PR TITLE
Adds tests to decotools

### DIFF
--- a/decotools/__init__.py
+++ b/decotools/__init__.py
@@ -1,4 +1,2 @@
 
-__version__ = '0.0.1'
-
 from .fileio import get_iOS_files

--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -106,8 +106,7 @@ def get_iOS_files(start_date=None, end_date=None, data_dir='/net/deco/iOSdata',
         dates = pd.date_range(start_date, end_date)
         dates = dates.strftime('%Y.%m.%d')
     except:
-        raise ValueError('Invalid start_date ({}) or end_date ({}) entered'.format(
-            start_date, end_date))
+        raise ValueError('Invalid start_date or end_date entered')
 
     # Build up list of all image files within the start_date to end_date range
     file_list = []

--- a/decotools/tests/test_fileio.py
+++ b/decotools/tests/test_fileio.py
@@ -1,0 +1,9 @@
+
+import pytest
+from decotools import fileio
+
+def test_no_files():
+    with pytest.raises(ValueError) as excinfo:
+        fileio.get_iOS_files(include_events=False, include_min_bias=False)
+    error = 'At least one of include_events or include_min_bias must be True.'
+    assert error == str(excinfo.value)

--- a/decotools/tests/test_fileio.py
+++ b/decotools/tests/test_fileio.py
@@ -2,8 +2,31 @@
 import pytest
 from decotools import fileio
 
-def test_no_files():
+
+def test_no_events_or_min_bias_fail():
     with pytest.raises(ValueError) as excinfo:
         fileio.get_iOS_files(include_events=False, include_min_bias=False)
     error = 'At least one of include_events or include_min_bias must be True.'
+    assert error == str(excinfo.value)
+
+
+def test_invalid_start_date_fail():
+    with pytest.raises(ValueError) as excinfo:
+        fileio.get_iOS_files(start_date='jamesbond')
+    error = 'Invalid start_date or end_date entered'
+    assert error == str(excinfo.value)
+
+
+def test_invalid_end_date_fail():
+    with pytest.raises(ValueError) as excinfo:
+        fileio.get_iOS_files(end_date='notadate')
+    error = 'Invalid start_date or end_date entered'
+    assert error == str(excinfo.value)
+
+
+def test_verbose_not_int_fail():
+    with pytest.raises(ValueError) as excinfo:
+        verbose = '0'
+        fileio.get_iOS_files(verbose=verbose)
+    error = 'Expecting an int for verbose, got {}'.format(type(verbose))
     assert error == str(excinfo.value)

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ Author: James Bourbeau + Mr. Meehan
 '''
 
 from setuptools import setup, find_packages
-import decotools
 
-VERSION = decotools.__version__
+VERSION = '0.0.1'
 
 setup(
     name='decotools',
@@ -15,5 +14,5 @@ setup(
     author='James Bourbeau + Mr. Meehan',
     author_email='jbourbeau@wisc.edu',
     packages=find_packages(),
-    install_requires=['numpy', 'pandas', 'mkdocs', 'mkdocs-cinder']
+    install_requires=['numpy', 'pandas', 'mkdocs', 'mkdocs-cinder', 'pytest']
 )


### PR DESCRIPTION
Adds `pytest` tests (right now just for `fileio.py`). Addressed issue #11 