### PR TITLE
Updates fileio to handle metadata file errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     author='James Bourbeau + Mr. Meehan',
     author_email='jbourbeau@wisc.edu',
     packages=find_packages(),
-    install_requires=['numpy', 'pandas', 'scikit-image', 'Pillow', 'matplotlib']
+    install_requires=['numpy', 'pandas', 'scikit-image', 'Pillow',
+                      'matplotlib']
 )


### PR DESCRIPTION
Fixes issue #23. This PR updates `fileio.py` in the following ways: 

- `fileio.py` can now handle empty xml metadata files and xml parsing error more gracefully 
- An `n_jobs` parameter has been added to run the metadata file parsing in parallel 