### PR TITLE
Fixes issue when empty list is passed to get_metadata_dataframe_batches

### DIFF
--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -115,7 +115,8 @@ def get_metadata_dataframe_batches(files):
 
 def get_metadata_dataframe(files, n_jobs=1):
 
-    batches = np.array_split(files, 100)
+    # Split files into batches to be processed (potentially) in parallel
+    batches = np.array_split(files, min(100, len(files)))
     df_list = [delayed(get_metadata_dataframe_batches)(batch) for batch in batches]
     df_merged = delayed(pd.concat)(df_list, ignore_index=True)
     print('Extracting metadata information:')

--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -76,6 +76,10 @@ def get_time_from_filename(image_file):
 
 def get_metadata_dataframe_batches(files):
 
+    # If files is empty, then just return an empty DataFrame
+    if not files:
+        return pd.DataFrame()
+
     xml_data = []
     for idx, image_file in enumerate(files):
         xml_file = image_file_to_xml_file(image_file)


### PR DESCRIPTION
During iOS metadata parsing, the list of files to be parsed are split into several batches to be (potentially) processed in parallel. However, when these batches are created, sometimes a batch will be empty (an empty list with no files). @cschneider6 saw that when there is an empty batch an error is thrown (see issue #27). This PR fixes that issue. 