### PR TITLE
Updates blob_extraction.py

### DIFF
--- a/decotools/blob_extraction.py
+++ b/decotools/blob_extraction.py
@@ -1,27 +1,27 @@
 
 import numpy as np
 import pandas as pd
-from PIL import Image
-from skimage import measure
+from skimage import io, measure
 
 
 def get_image_array(image_file):
 
-    img = Image.open(image_file)
-    img = img.convert('L')
-    # Convert img to a numpy array
-    image = np.asarray(img, dtype=float).T
+    image = io.imread(image_file)
+    # Convert RGB image to R+G+B grayscale
+    image = np.sum(image[:, :, :-1], axis=2)
 
     return image
 
 
 class Blob(object):
     '''Class that defines a 'blob' in an image: the contour of a set of pixels
-       with values above a given threshold.'''
+       with values above a given threshold.
+    '''
 
     def __init__(self, x, y):
         '''Define a counter by its contour lines (an list of points in the xy
-           plane), the contour centroid, and its enclosed area.'''
+           plane), the contour centroid, and its enclosed area.
+        '''
         self.x = np.array(x)
         self.y = np.array(y)
         self.xc = np.mean(x)
@@ -35,7 +35,7 @@ class Blob(object):
         self.area = area
 
     def __repr__(self):
-        str_rep = 'Blob(x={}, y={}, area={})'.format(self.xc, self.yc, self.area)
+        str_rep = 'Blob(xc={}, yc={}, area={})'.format(self.xc, self.yc, self.area)
         return str_rep
 
     def length(self):
@@ -59,13 +59,13 @@ def findblobs(image, threshold, min_area=2., max_area=1000.):
        threshold value.  The min_area parameter is used to exclude blobs with an
        area below this value.'''
     blobs = []
-    ny, nx = image.shape
+    nx, ny = image.shape
 
     # Find contours using the Marching Squares algorithm in the scikit package.
     contours = measure.find_contours(image, threshold)
     for contour in contours:
-        x = contour[:,1]
-        y = ny - contour[:,0]
+        y = contour[:,1]
+        x = contour[:,0]
         blob = Blob(x, y)
         if blob.area >= min_area and blob.area <= max_area:
             blobs.append(blob)
@@ -86,9 +86,11 @@ class BlobGroup(object):
         self.ymin =  1e10
         self.ymax = -1e10
         self.image = image
+        self.xc = None
+        self.yc = None
 
     def __repr__(self):
-        str_rep = 'BlobGroup(n_blobs={})'.format(len(self.blobs))
+        str_rep = 'BlobGroup(n_blobs={}, xc={}, yc={})'.format(len(self.blobs), self.xc, self.yc)
         return str_rep
 
     def add_blob(self, blob):
@@ -99,7 +101,6 @@ class BlobGroup(object):
         self.xmax = max(self.xmax, blob.x.max())
         self.ymin = min(self.ymin, blob.y.min())
         self.ymax = max(self.ymax, blob.y.max())
-        self.cov  = None
         self.xc = np.mean([blob.xc for blob in self.blobs])
         self.yc = np.mean([blob.yc for blob in self.blobs])
 
@@ -128,7 +129,7 @@ class BlobGroup(object):
         if image is None:
             image = self.image.copy()
 
-        ny,nx = image.shape
+        nx, ny = image.shape
         if square and not size:
             x0,x1,y0,y1 = self.get_square_bounding_box()
         if square and size:
@@ -139,58 +140,18 @@ class BlobGroup(object):
             x0,x1,y0,y1 = self.get_bounding_box()
 
         # Account for all the weird row/column magic in the image table...
-        i0,i1 = [ny - int(t) for t in (y1,y0)]
-        j0,j1 = [int(t) for t in (x0,x1)]
+        i0, i1 = int(x0), int(x1)
+        j0, j1 = int(y0), int(y1)
 
         # Add a pixel buffer around the bounds, and check the ranges
         buf = 1
         i0 = 0 if i0-buf < 0 else i0-buf
-        i1 = ny-1 if i1 > ny-1 else i1+buf
+        i1 = nx-1 if i1 > nx-1 else i1+buf
         j0 = 0 if j0-buf < 0 else j0-buf
-        j1 = nx-1 if j1 > nx-1 else j1+buf
+        j1 = ny-1 if j1 > ny-1 else j1+buf
 
         return image[i0:i1, j0:j1]
 
-    def get_raw_moment(self, image, p, q):
-        '''Calculate the image moment given by
-           M_{ij}=\sum_x\sum_y x^p y^q I(x,y)
-           where I(x,y) is the image intensity at location x,y.'''
-        nx,ny = image.shape
-        Mpq = 0.
-        if p == 0 and q == 0:
-            Mpq = np.sum(image)
-        else:
-            for i in range(0,nx):
-                x = 0.5 + i
-                for j in range(0,ny):
-                    y = 0.5 + j
-                    Mpq += x**p * y**q * image[i,j]
-        return Mpq
-
-    def get_hu_moments(self, image):
-        """Calcuate the Hu moments, which are translation, scale, and
-        rotation invariant using skimage.measure.
-
-        Additionally calculate an 8th moment to complete the set as
-        described here:
-        https://en.wikipedia.org/wiki/Image_moment#Raw_moments
-        """
-
-        subImage = self.get_sub_image(image).transpose()
-        moments = measure.moments(subImage)
-        centroid_row = moments[0, 1] / moments[0, 0]
-        centroid_column = moments[1, 0] / moments[0, 0]
-        moments_central = measure.moments_central(image,
-                          centroid_row, centroid_column)
-        moments_normalized = measure.moments_normalized(moments_central)
-        moments_hu = measure.moments_hu(moments_normalized)
-
-        # Calculate the 8th Hu moment
-        mn = moments_normalized
-        hu_8 = mn[1][1]*((mn[3][0]+mn[1][2])**2-(mn[0][3]+mn[2][1])**2)\
-               - (mn[2][0]-mn[0][2])*(mn[3][0]+mn[1][2])*(mn[0][3]+mn[2][1])
-        moments_hu = np.append(moments_hu,hu_8)
-        return moments_hu
 
     def get_region_props(self, threshold, square=True):
 
@@ -202,56 +163,6 @@ class BlobGroup(object):
             raise ValueError('Image has more than one region!')
 
         return region_properties[0]
-
-    def get_max_intensity(self, image):
-        '''Find the maximum intensity within the blob
-           where I(x,y) is the image intensity at location x,y.'''
-        nx,ny = image.shape
-        maxI = 0.
-        for i in range(0,nx):
-            for j in range(0,ny):
-                if image[i,j] > maxI: maxI = image[i,j]
-        return maxI
-
-    # Not sure if this works
-    def get_area(self, image):
-        '''Calculate image area from image moment 00.'''
-        M00 = -999
-        subImage = self.get_sub_image(image).transpose()
-        M00 = self.get_raw_moment(subImage, 0, 0)
-        return M00
-
-    def get_covariance(self, image):
-        '''Get the raw moments of the image region inside the bounding box
-           defined by this blob group and calculate the image covariance
-           matrix.'''
-        if self.cov == None:
-            subImage = self.get_sub_image(image).transpose()
-            M00 = self.get_raw_moment(subImage, 0, 0)
-            M10 = self.get_raw_moment(subImage, 1, 0)
-            M01 = self.get_raw_moment(subImage, 0, 1)
-            M11 = self.get_raw_moment(subImage, 1, 1)
-            M20 = self.get_raw_moment(subImage, 2, 0)
-            M02 = self.get_raw_moment(subImage, 0, 2)
-            xbar = M10/M00
-            ybar = M01/M00
-            self.cov = np.vstack([[M20/M00 - xbar*xbar, M11/M00 - xbar*ybar],
-                                  [M11/M00 - xbar*ybar, M02/M00 - ybar*ybar]])
-        return self.cov
-
-    def get_principal_moments(self, image):
-        '''Return the maximum and minimum eigenvalues of the covariance matrix,
-           as well as the angle theta between the maximum eigenvector and the
-           x-axis.'''
-        cov = self.get_covariance(image)
-        u20 = cov[0,0]
-        u11 = cov[0,1]
-        u02 = cov[1,1]
-
-        theta = 0.5 * np.arctan2(2*u11, u20-u02)
-        l1 = 0.5*(u20+u02) + 0.5*np.sqrt(4*u11**2 + (u20-u02)**2)
-        l2 = 0.5*(u20+u02) - 0.5*np.sqrt(4*u11**2 + (u20-u02)**2)
-        return l1, l2, theta
 
 
 def group_blobs(image, blobs, max_dist):
@@ -271,16 +182,16 @@ def group_blobs(image, blobs, max_dist):
 
         for i in range(1, n):
             bi = blobs[i]
-            isGrouped = False
+            is_grouped = False
             for group in groups:
                 # Calculate distance measure for a blob and a blob group:
                 # blob just has to be < max_dist from any other blob in the group
                 for bj in group.blobs:
                     if bi.distance(bj) < max_dist:
                         group.add_blob(bi)
-                        isGrouped = True
+                        is_grouped = True
                         break
-            if not isGrouped:
+            if not is_grouped:
                 bg = BlobGroup(image=image)
                 bg.add_blob(bi)
                 groups.append(bg)
@@ -349,7 +260,7 @@ def extract_blobs(image_file, threshold=20., min_area=10., max_area=1000.,
         prop_dict['xc'] = group.xc
         prop_dict['yc'] = group.yc
         prop_dict['image'] = group.get_sub_image(square=square,
-                                 size=prop_dict['equivalent_diameter']).T
+                                 size=prop_dict['equivalent_diameter'])
         prop_dict['image_file'] = image_file
 
         if group_max_area and prop_dict['area'] > group_max_area:

--- a/decotools/fileio.py
+++ b/decotools/fileio.py
@@ -77,7 +77,7 @@ def get_time_from_filename(image_file):
 def get_metadata_dataframe_batches(files):
 
     # If files is empty, then just return an empty DataFrame
-    if not files:
+    if len(files) == 0:
         return pd.DataFrame()
 
     xml_data = []


### PR DESCRIPTION
This PR updates a few things:

1. Fixes issue #29. 

2. Updates `blob_extraction.py` so that the grayscale conversion is now a simple R+G+B sum instead of the weighted rgb values used in PIL. 

3. Gets rid of all the image transposes in `blob_extraction.py` due to the column-oriented PIL image object vs. the row-oriented scikit-image array

4. Removes all the legacy image calculations (area, principle moments, etc.). Given that these are now done with `skimage.measure.regionprops`. 