### PR TITLE
Moves CV validation into fit method

### DIFF
--- a/decotools/convnet.py
+++ b/decotools/convnet.py
@@ -500,7 +500,7 @@ class CNN(object):
         """
         # Validate user input
         if not self.training:
-            raise ValueError('CNN class initialized with training=\'False\','
+            raise ValueError('CNN class initialized with training=\'False\', '
                              'must be \'True\'')
 
         train_images, train_labels = _check_shape(train_images, train_labels)
@@ -533,7 +533,6 @@ class CNN(object):
                     check_point_weights_only=check_point_weights_only)
 
         if cv is None:
-            # Save model, weights, history
             self._fit(train_images, train_labels,
                       test_images=test_images, test_labels=test_labels,
                       check_point=check_point,

--- a/decotools/convnet.py
+++ b/decotools/convnet.py
@@ -127,20 +127,20 @@ class CNN(object):
     ----------
     weights_file : str, optional
         Path and file name of an hdf5 file containing the trained model
-        weights to be used by the CNN. (default: None)
+        weights to be used by the CNN (default is None).
     model_file : str, optional
         Path and file name of an hdf5 file containing a trained model.
         Typically, this should only be used when continuing an existing
-        training session. (default: None)
+        training session (default is None).
     custom_model : keras model, optional
         User-defined, compiled keras model to be used in place of the
-        default (default: None)
+        default (default is None).
     training : bool, optional
         If True, initializes the model structure used for training. If
-        False, initializes the model structure used for predictions.
-        (default: False)
-    n_classes : int
-        Number of classes to be used by the CNN. (default: 4)
+        False, initializes the model structure used for predictions
+        (default is False).
+    n_classes : int, optional
+        Number of classes to be used by the CNN (default is 4).
 
     """
     def __init__(self, weights_file=None, model_file=None, custom_model=None,
@@ -261,7 +261,7 @@ class CNN(object):
         numpy.ndarray
             Array containing smoothed one-hot row-vector labels
         """
-        y = np.asarray(y)
+        y = np.array(y, copy=True)
         assert len(y.shape) == 2
         if 0 <= smooth_factor <= 1:
             y *= 1 - smooth_factor
@@ -278,13 +278,13 @@ class CNN(object):
         ----------
         images : numpy.ndarray
             Array of grayscale, normalized images to be used for evaluation.
-            Input shape = (n_image,n_row,n_cols,1)
+            Input shape = (n_image,n_row,n_cols,1).
         labels : numpy.ndarray
-            Array of labels to be used for evaluation, shape=(n_images,)
-        batch_size : int
-            Batch size to use for predictions (default: 32)
-        verbose : int
-            Verbosity mode to use, 0 or 1 (default: 0)
+            Array of labels to be used for evaluation, shape=(n_images,).
+        batch_size : int, optional
+            Batch size to use for predictions (default is 32).
+        verbose : int, optional
+            Verbosity mode to use, 0 or 1 (default is 0).
 
         Returns
         -------
@@ -302,18 +302,17 @@ class CNN(object):
         print(self.model.summary())
 
     def predict(self, images, batch_size=32, verbose=0):
-        """
-        Predict classifications for an array of images
+        """ Predict classifications for an input image array
 
         Parameters
         ----------
         images : numpy.ndarray
             Array of grayscale, normalized images to be used for class
             predictions. Input shape = (n_image,n_row,n_cols,1)
-        batch_size : int
-            Batch size to use for predictions (default: 32)
-        verbose : int
-            Verbosity mode to use, 0 or 1 (default: 0)
+        batch_size : int, optional
+            Batch size to use for predictions (default is 32).
+        verbose : int, optional
+            Verbosity mode to use, 0 or 1 (default is 0).
 
         Returns
         -------
@@ -420,14 +419,14 @@ class CNN(object):
         ----------
         train_images : numpy.ndarray
             Array of grayscale, normalized images to be used for training the
-            CNN. Input shape = (n_image,n_row,n_cols,1)
+            CNN. Input shape = (n_image,n_row,n_cols,1).
         train_labels : numpy.ndarray
-            Array of training labels, shape=(n_images,)
+            Array of training labels, shape=(n_images,).
         test_images : numpy.ndarray, optional
             Array of grayscale, normalized images to be used for testing the
-            CNN. Input shape = (n_image,n_row,n_cols,1)
+            CNN. Input shape = (n_image,n_row,n_cols,1).
         test_labels : numpy.ndarray, optional
-            Array of testing labels, shape=(n_images,)
+            Array of testing labels, shape=(n_images,).
         cv : int, scikit-learn cross validator, None, optional
             Option for cross-validation fitting. If ``cv`` is an integer
             ``sklearn.model_selection.StratifiedKFold`` will be used with
@@ -435,68 +434,71 @@ class CNN(object):
             ``sklearn.model_selection`` can be passed to ``cv`` as well
             (default is None).
         batch_size : int, optional
-            Number of samples per gradient update (default: 32)
+            Number of samples per gradient update (default is 32).
         seed : int, optional
-            Random seed to be used for reproducibility. (default: None)
+            Random seed to be used for reproducibility. (default is None).
         epochs : int, optional
             Number of epochs to train the model. Note that in conjunction with
             initial_epoch, the parameter epochs is to be understood as
-            "final epoch". (default: 10)
+            "final epoch". (default is 10).
         initial_epoch : int, optional
-            Epoch at which to start training (useful for resuming a previous
-            training run). (default: 0)
-        smooth_factor : float between 0,1, optional
+            Epoch at which to start training. Useful for resuming a previous
+            training run (default is 0).
+        smooth_factor : float in range (0, 1), optional
             Level of smoothing to apply to one-hot label vector. Ex.
             smooth_factor of 0.004 applied to [0, 1, 0, 0], results in
-            [0.001, 0.997, 0.001, 0.001]. (default: None)
+            [0.001, 0.997, 0.001, 0.001] (default is None).
         horizontal_flip : bool, optional
-            Randomly flip inputs horizontally. (default: True)
+            Randomly flip inputs horizontally (default is True).
         vertical_flip : bool, optional
-            Randomly flip inputs vertically. (default: True)
-        width_shift_range : Float (fraction of total width), optional
-            Range for random horizontal shifts. (default: 0.08)
-        height_shift_range : Float (fraction of total height), optional
-            Range for random vertical shifts. (default: 0.08)
+            Randomly flip inputs vertically (default is True).
+        width_shift_range : float, optional
+            Range for random horizontal shifts (default is 0.08).
+        height_shift_range : float, optional
+            Range for random vertical shifts (default is 0.08).
         rotation_range : int, optional
-            Degree range for random rotations (default: 180)
-        zoom_range : float or [lower, upper], optional
-            Range for random zoom. If a float, [lower, upper] = [1-zoom_range,
-            1+zoom_range] (default: [0.9, 1.1])
+            Degree range for random rotations (default is 180).
+        zoom_range : float or (lower, upper), optional
+            Range for random zoom. If a float,
+            ``(lower, upper) = (1-zoom_range, 1+zoom_range)`` (default
+            is ``(0.9, 1.1)``).
         fill_mode : {"constant", "nearest", "reflect" or "wrap"}, optional
             Points outside the boundaries of the input are filled according to
-            the given mode. (default: "constant")
+            the given mode (default is "constant").
         cval : float or int, optional
-            Value used for interpolated pixels when fill_mode = "constant".
-            (default: 0)
+            Value used for interpolated pixels when ``fill_mode="constant"``
+            (default is 0).
         shuffle : bool, optional
             Whether to shuffle the order of the batches at the beginning of
-            each epoch. (default: True)
+            each epoch (default is True).
         save_model : str, optional
             If specified, a copy of the model from the final training epoch
-            will be saved. ex. save_model='my_model.h5'. Typically used for
-            continued training (default: None)
+            will be saved. For example, ``save_model='my_model.h5'``.
+            Typically used for continued training (default is None).
         save_weights : str, optional
             If specified, a copy of the model weights from the final training
-            epoch will be saved. ex. save_weights='my_weights.h5'.
-            (default: None)
+            epoch will be saved. For example, ``save_weights='my_weights.h5'``
+            (default is None).
         save_history : str, optional
             If specified, the training history (accuracy and loss for training
-            and testing) from each epoch will be saved to a '.csv'.
-            ex. save_history='my_history.csv'. (default: None)
+            and testing) from each epoch will be saved to a CSV file.
+            For example, ``save_history='my_history.csv'`` (default is None).
         check_point : str, optional
             If specified, saves a running copy of the model corresponding to
             the lowest validation loss epoch. Each time a new low is reached,
-            the previous best model is over-written by the new one
-            (default is None).
+            the previous best model is over-written by the new one.
+            For example, ``check_point='my_checkpoint.h5'`` (default is None).
         check_point_weights_only : bool, optional
-            If True, then only the model's weights will be saved, else the full
-            model is saved. Ignored if check_point = False. (default: True)
+            If True, only the model's weights will be saved in the check
+            point. Otherwise the full model is saved. Ignored if
+            ``check_point=False`` (default is True).
         verbose : bool, optional
             Option for verbose output.
 
         Returns
         -------
         self : CNN
+            Trained CNN.
         """
         # Validate user input
         if not self.training:

--- a/decotools/convnet.py
+++ b/decotools/convnet.py
@@ -12,7 +12,7 @@ from keras.constraints import maxnorm
 from keras.utils import to_categorical
 from keras.preprocessing.image import ImageDataGenerator
 from keras.callbacks import ModelCheckpoint
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import BaseCrossValidator, StratifiedKFold
 
 
 def get_crop_range(maxX, maxY, size=32):
@@ -150,8 +150,6 @@ class CNN(object):
         self.custom_model = custom_model
         self.n_classes = n_classes
         self.training = training
-        self.train_indices = []
-        self.test_indices = []
         if custom_model:
             self.model = custom_model
         else:
@@ -328,136 +326,34 @@ class CNN(object):
         return self.model.predict(images, batch_size=batch_size,
                                   verbose=verbose)
 
-    def fit(self, train_images, train_labels, test_images, test_labels,
-            batch_size=32, seed=None, epochs=10, initial_epoch=0,
-            smooth_factor=None, horizontal_flip=True,
-            vertical_flip=True, width_shift_range=0.08,
-            height_shift_range=0.08, rotation_range=180.,
-            zoom_range=(0.9, 1.1), fill_mode='constant', cval=0,
-            shuffle=True, save_model=None, save_weights=None,
-            save_history=None, output_dir=None, verbose=False,
-            check_point=False, check_point_weights_only=True):
-        """Train CNN
-
-        Parameters
-        ----------
-        train_images : numpy.ndarray
-            Array of grayscale, normalized images to be used for training the
-            CNN. Input shape = (n_image,n_row,n_cols,1)
-        train_labels : numpy.ndarray
-            Array of training labels, shape=(n_images,)
-        test_images : numpy.ndarray
-            Array of grayscale, normalized images to be used for testing the
-            CNN. Input shape = (n_image,n_row,n_cols,1)
-        test_labels : numpy.ndarray
-            Array of testing labels, shape=(n_images,)
-        batch_size : int
-            Number of samples per gradient update (default: 32)
-        seed : int
-            Random seed to be used for reproducibility. (default: None)
-        epochs : int
-            Number of epochs to train the model. Note that in conjunction with
-            initial_epoch, the parameter epochs is to be understood as
-            "final epoch". (default: 10)
-        initial_epoch : int
-            Epoch at which to start training (useful for resuming a previous
-            training run). (default: 0)
-        smooth_factor : float between 0,1
-            Level of smoothing to apply to one-hot label vector. Ex.
-            smooth_factor of 0.004 applied to [0, 1, 0, 0], results in
-            [0.001, 0.997, 0.001, 0.001]. (default: None)
-        horizontal_flip : bool
-            Randomly flip inputs horizontally. (default: True)
-        vertical_flip : bool
-            Randomly flip inputs vertically. (default: True)
-        width_shift_range : Float (fraction of total width)
-            Range for random horizontal shifts. (default: 0.08)
-        height_shift_range : Float (fraction of total height)
-            Range for random vertical shifts. (default: 0.08)
-        rotation_range : int
-            Degree range for random rotations (default: 180)
-        zoom_range : float or [lower, upper].
-            Range for random zoom. If a float, [lower, upper] = [1-zoom_range,
-            1+zoom_range] (default: [0.9, 1.1])
-        fill_mode : One of {"constant", "nearest", "reflect" or "wrap"}
-            Points outside the boundaries of the input are filled according to
-            the given mode. (default: "constant")
-        cval : float or int
-            Value used for interpolated pixels when fill_mode = "constant".
-            (default: 0)
-        shuffle : bool
-            Whether to shuffle the order of the batches at the beginning of
-            each epoch. (default: True)
-        save_model : str
-            If specified, a copy of the model from the final training epoch
-            will be saved. ex. save_model='my_model.h5'. Typically used for
-            continued training (default: None)
-        save_weights : str
-            If specified, a copy of the model weights from the final training
-            epoch will be saved. ex. save_weights='my_weights.h5'.
-            (default: None)
-        save_history : str
-            If specified, the training history (accuracy and loss for training
-            and testing) from each epoch will be saved to a '.csv'.
-            ex. save_history='my_history.csv'. (default: None)
-        output_dir : str
-            If specified, all model outputs will be saved to the specified
-            directory. (default: current working directory)
-        verbose : bool, optional
-            Option for verbose output.
-        check_point : bool
-            If True, saves a running copy of the model corresponding to the
-            lowest validation loss epoch. Each time a new low is reached, the
-            previous best model is over-written by the new one. Model saved as
-            'best_checkpointed_model.h5'. (default: False)
-        check_point_weights_only : bool
-            If True, then only the model's weights will be saved, else the full
-            model is saved. Ignored if check_point = False. (default: True)
-
-        Returns
-        -------
-        self : CNN
-        """
-        # Validate user input
-        if not self.training:
-            raise ValueError('CNN class initialized with training=\'False\','
-                             'must be \'True\'')
-
-        if not train_images.shape[0] == train_labels.shape[0]:
-            raise ValueError('The number of training labels does not match '
-                             'the number of training images')
-        if not test_images.shape[0] == test_labels.shape[0]:
-            raise ValueError('The number of testing labels does not match '
-                             'the number of testing images')
-
-        if batch_size > train_images.shape[0]:
-            raise ValueError(
-                    'batch_size must be <= the number of training images')
-
-        if seed:
-            np.random.seed(seed)
-
-        # Set output directory
-        if not output_dir:
-            output_dir = os.getcwd()
-
-        # Calculate class weights
-        self._calculate_class_weights(train_labels)
+    def _fit(self, train_images, train_labels, test_images=None,
+             test_labels=None, batch_size=32, seed=None, epochs=10,
+             initial_epoch=0, smooth_factor=None, horizontal_flip=True,
+             vertical_flip=True, width_shift_range=0.08,
+             height_shift_range=0.08, rotation_range=180.,
+             zoom_range=(0.9, 1.1), fill_mode='constant', cval=0,
+             shuffle=True, save_model=None, save_weights=None,
+             save_history=None, check_point=None,
+             check_point_weights_only=True, verbose=False):
 
         # Convert labels to one-hot and apply smoothing
         train_labels = to_categorical(train_labels, self.n_classes)
         if smooth_factor:
             train_labels = self._smooth_labels(train_labels, smooth_factor)
-        test_labels = to_categorical(test_labels, self.n_classes)
+        if test_labels is not None:
+            test_labels = to_categorical(test_labels, self.n_classes)
+            validation_data = (test_images, test_labels)
+        else:
+            validation_data = None
 
         # Setup checkpointer
-        checkpointer = None
-        if check_point:
-            filepath = os.path.join(output_dir, 'best_checkpointed_model.h5')
-            checkpointer = [ModelCheckpoint(filepath,
+        if check_point is not None:
+            checkpointer = [ModelCheckpoint(check_point,
                             monitor='val_loss', verbose=0,
                             save_weights_only=check_point_weights_only,
                             save_best_only=True, mode='auto')]
+        else:
+            checkpointer = None
 
         # Preprocess images
         datagen = ImageDataGenerator(
@@ -472,132 +368,131 @@ class CNN(object):
 
         # Fit the model
         datagen.fit(train_images)
-        hist = self.model.fit_generator(datagen.flow(
-                        train_images,
-                        train_labels,
-                        batch_size=batch_size,
-                        seed=seed,
-                        shuffle=shuffle),
-                        steps_per_epoch=train_images.shape[0] // batch_size,
-                        epochs=epochs,
-                        class_weight=self.class_weights,
-                        callbacks=checkpointer,
-                        validation_data=(test_images, test_labels),
-                        initial_epoch=initial_epoch)
+        steps_per_epoch = train_images.shape[0] // batch_size
+        hist = self.model.fit_generator(datagen.flow(train_images,
+                                                     train_labels,
+                                                     batch_size=batch_size,
+                                                     seed=seed,
+                                                     shuffle=shuffle),
+                                        steps_per_epoch=steps_per_epoch,
+                                        epochs=epochs,
+                                        class_weight=self.class_weights,
+                                        callbacks=checkpointer,
+                                        validation_data=validation_data,
+                                        initial_epoch=initial_epoch)
 
         # Evaluate  model
-        score = self.model.evaluate(test_images, test_labels, verbose=0)
-        if verbose:
-            print('Final test loss:', score[0])
-            print('Final test accuracy:', score[1])
+        if validation_data:
+            score = self.model.evaluate(test_images, test_labels, verbose=0)
+            if verbose:
+                print('Final test loss:', score[0])
+                print('Final test accuracy:', score[1])
 
         # Save model, weights, history
         if save_model:
-            self.model.save('{}/{}'.format(output_dir, save_model))
+            self.model.save(save_model)
         if save_weights:
-            self.model.save_weights('{}/{}'.format(output_dir, save_weights))
+            self.model.save_weights(save_weights)
         if save_history:
             hist_vals = np.array([hist.history['acc'],
                                   hist.history['val_acc'],
                                   hist.history['loss'],
                                   hist.history['val_loss']])
-            np.savetxt('{}/{}'.format(output_dir, save_history),
+            np.savetxt(save_history,
                        np.transpose(hist_vals),
                        delimiter=',',
                        header='acc,val_acc,loss,val_loss')
 
         return self
 
-    def fit_with_kfold(self, images, labels, k_folds=10, seed=None,
-                       shuffle=True, batch_size=32, epochs=10,
-                       initial_epoch=0, smooth_factor=None,
-                       horizontal_flip=True, vertical_flip=True,
-                       width_shift_range=0.08, height_shift_range=0.08,
-                       rotation_range=180., zoom_range=(0.9, 1.1),
-                       fill_mode="constant", cval=0, save_model=None,
-                       save_weights=None, save_history=None, output_dir=None,
-                       verbose=False, check_point=False,
-                       check_point_weights_only=True):
-
-        """Train CNN using kfold cross validation
+    def fit(self, train_images, train_labels, test_images=None,
+            test_labels=None, cv=None, batch_size=32, seed=None, epochs=10,
+            initial_epoch=0, smooth_factor=None, horizontal_flip=True,
+            vertical_flip=True, width_shift_range=0.08,
+            height_shift_range=0.08, rotation_range=180.,
+            zoom_range=(0.9, 1.1), fill_mode='constant', cval=0,
+            shuffle=True, save_model=None, save_weights=None,
+            save_history=None, check_point=None,
+            check_point_weights_only=True, verbose=False):
+        """Fit CNN
 
         Parameters
         ----------
-        images : numpy.ndarray
-            Array of grayscale, normalized images to be used for training and
-            testing the CNN. shape = (n_image,n_row,n_cols,1)
-        labels : numpy.ndarray
-            Array of labels to be used for training and testing the CNN.
-            shape=(n_images,)
-        k_folds : int
-            Number of folds to use for k-fold cross validation. (default: 10)
-        seed : int
-            Random seed to be used for reproducibility. (default: None)
-        batch_size : int
+        train_images : numpy.ndarray
+            Array of grayscale, normalized images to be used for training the
+            CNN. Input shape = (n_image,n_row,n_cols,1)
+        train_labels : numpy.ndarray
+            Array of training labels, shape=(n_images,)
+        test_images : numpy.ndarray, optional
+            Array of grayscale, normalized images to be used for testing the
+            CNN. Input shape = (n_image,n_row,n_cols,1)
+        test_labels : numpy.ndarray, optional
+            Array of testing labels, shape=(n_images,)
+        cv : int, scikit-learn cross validator, None, optional
+            Option for cross-validation fitting. If ``cv`` is an integer
+            ``sklearn.model_selection.StratifiedKFold`` will be used with
+            ``cv`` number of folds. Other cross validators from
+            ``sklearn.model_selection`` can be passed to ``cv`` as well
+            (default is None).
+        batch_size : int, optional
             Number of samples per gradient update (default: 32)
-        epochs : int
+        seed : int, optional
+            Random seed to be used for reproducibility. (default: None)
+        epochs : int, optional
             Number of epochs to train the model. Note that in conjunction with
             initial_epoch, the parameter epochs is to be understood as
             "final epoch". (default: 10)
-        initial_epoch : int
+        initial_epoch : int, optional
             Epoch at which to start training (useful for resuming a previous
             training run). (default: 0)
-        smooth_factor : float between 0,1
+        smooth_factor : float between 0,1, optional
             Level of smoothing to apply to one-hot label vector. Ex.
             smooth_factor of 0.004 applied to [0, 1, 0, 0], results in
             [0.001, 0.997, 0.001, 0.001]. (default: None)
-        horizontal_flip : bool
+        horizontal_flip : bool, optional
             Randomly flip inputs horizontally. (default: True)
-        vertical_flip : bool
+        vertical_flip : bool, optional
             Randomly flip inputs vertically. (default: True)
-        width_shift_range : Float (fraction of total width)
+        width_shift_range : Float (fraction of total width), optional
             Range for random horizontal shifts. (default: 0.08)
-        height_shift_range : Float (fraction of total height)
+        height_shift_range : Float (fraction of total height), optional
             Range for random vertical shifts. (default: 0.08)
-        rotation_range : int
+        rotation_range : int, optional
             Degree range for random rotations (default: 180)
-        zoom_range : float or [lower, upper].
+        zoom_range : float or [lower, upper], optional
             Range for random zoom. If a float, [lower, upper] = [1-zoom_range,
             1+zoom_range] (default: [0.9, 1.1])
-        fill_mode : One of {"constant", "nearest", "reflect" or "wrap"}
+        fill_mode : {"constant", "nearest", "reflect" or "wrap"}, optional
             Points outside the boundaries of the input are filled according to
             the given mode. (default: "constant")
-        cval : float or int
+        cval : float or int, optional
             Value used for interpolated pixels when fill_mode = "constant".
             (default: 0)
-        shuffle : bool
+        shuffle : bool, optional
             Whether to shuffle the order of the batches at the beginning of
             each epoch. (default: True)
-        save_model : str
+        save_model : str, optional
             If specified, a copy of the model from the final training epoch
-            will be saved. ex. save_model='my_model.h5' will save models as
-            'my_model_k.h5', where k is the current fold being trained.
-            Typically used for continued training (default: None)
-        save_weights : str
+            will be saved. ex. save_model='my_model.h5'. Typically used for
+            continued training (default: None)
+        save_weights : str, optional
             If specified, a copy of the model weights from the final training
-            epoch will be saved. ex. save_weights='my_weights.h5' will save
-            weights as 'my_weights_k.h5', where k is the current fold being
-            trained. (default: None)
-        save_history : str
-            If specified, the training history (accuracy and loss for training
-            and testing) from each epoch will be saved to a '.csv'. ex.
-            save_history='my_history.csv' will save history as
-            'my_history_k.csv', where k is the current fold being trained.
+            epoch will be saved. ex. save_weights='my_weights.h5'.
             (default: None)
-        output_dir : str
-            If specified, all model outputs will be saved to the specified
-            directory. (default: current working directory)
-        verbose : bool, optional
-            Option for verbose output.
-        check_point : bool
-            If True, saves a running copy of the model corresponding to the
-            lowest validation loss epoch. Each time a new low is reached, the
-            previous best model is over-written by the new one. Model saved as
-            'best_checkpointed_model_k.h5', where k is the current fold being
-            trained. (default: False)
-        check_point_weights_only : bool
+        save_history : str, optional
+            If specified, the training history (accuracy and loss for training
+            and testing) from each epoch will be saved to a '.csv'.
+            ex. save_history='my_history.csv'. (default: None)
+        check_point : str, optional
+            If specified, saves a running copy of the model corresponding to
+            the lowest validation loss epoch. Each time a new low is reached,
+            the previous best model is over-written by the new one
+            (default is None).
+        check_point_weights_only : bool, optional
             If True, then only the model's weights will be saved, else the full
             model is saved. Ignored if check_point = False. (default: True)
+        verbose : bool, optional
+            Option for verbose output.
 
         Returns
         -------
@@ -608,117 +503,132 @@ class CNN(object):
             raise ValueError('CNN class initialized with training=\'False\','
                              'must be \'True\'')
 
-        if not images.shape[0] == labels.shape[0]:
-            raise ValueError('The number of training labels does not match '
-                             'the number of training images')
+        train_images, train_labels = _check_shape(train_images, train_labels)
+        if test_labels is not None:
+            test_images, test_labels = _check_shape(test_images, test_labels)
 
-        if batch_size > images.shape[0]:
+        if batch_size > train_images.shape[0]:
             raise ValueError(
                     'batch_size must be <= the number of training images')
+        if (cv is not None) and (test_labels is not None):
+            raise ValueError('Cross-validation fitting and an explicitly '
+                             'given testing set can\'t be used at the '
+                             'same time')
+
         if seed:
             np.random.seed(seed)
 
-        # Set output directory
-        if not output_dir:
-            output_dir = os.getcwd()
-
         # Calculate class weights
-        self._calculate_class_weights(labels)
+        self._calculate_class_weights(train_labels)
 
-        # Store initial weights
-        init_weights = self.model.get_weights()
+        args = dict(batch_size=batch_size, seed=seed, epochs=epochs,
+                    initial_epoch=initial_epoch, smooth_factor=smooth_factor,
+                    horizontal_flip=horizontal_flip,
+                    vertical_flip=vertical_flip,
+                    width_shift_range=width_shift_range,
+                    height_shift_range=height_shift_range,
+                    rotation_range=rotation_range, zoom_range=zoom_range,
+                    fill_mode=fill_mode, cval=cval, shuffle=shuffle,
+                    verbose=verbose,
+                    check_point_weights_only=check_point_weights_only)
 
-        # Split into testing and training sets
-        skf = StratifiedKFold(n_splits=k_folds, shuffle=shuffle,
-                              random_state=seed)
-        skf.get_n_splits(images, labels)
-
-        for i, indices in enumerate(skf.split(images, labels)):
-            if verbose:
-                print('Training Fold Number {}'.format(i))
-
-            # Get testing and training split for this fold
-            train_index, test_index = indices
-            train_images, test_images = images[train_index], images[test_index]
-            train_labels, test_labels = labels[train_index], labels[test_index]
-            self.train_indices.append(train_index)
-            self.test_indices.append(test_index)
-
-            # Convert labels to one-hot and apply smoothing
-            train_labels = to_categorical(train_labels, self.n_classes)
-            if smooth_factor:
-                train_labels = self._smooth_labels(train_labels, smooth_factor)
-            test_labels = to_categorical(test_labels, self.n_classes)
-
-            # Setup checkpointer
-            checkpointer = None
-            if check_point:
-                filepath = os.path.join(output_dir,
-                                        'best_checkpointed_model.h5')
-                checkpointer = [ModelCheckpoint(filepath,
-                                monitor='val_loss', verbose=0,
-                                save_weights_only=check_point_weights_only,
-                                save_best_only=True, mode='auto')]
-
-            # Preprocess images
-            datagen = ImageDataGenerator(
-                            horizontal_flip=horizontal_flip,
-                            vertical_flip=vertical_flip,
-                            width_shift_range=width_shift_range,
-                            height_shift_range=height_shift_range,
-                            rotation_range=rotation_range,
-                            zoom_range=zoom_range,
-                            fill_mode=fill_mode,
-                            cval=cval)
-
-            # Fit the model
-            datagen.fit(train_images)
-            hist = self.model.fit_generator(datagen.flow(
-                        train_images,
-                        train_labels,
-                        batch_size=batch_size,
-                        seed=seed,
-                        shuffle=shuffle),
-                        steps_per_epoch=train_images.shape[0] // batch_size,
-                        epochs=epochs,
-                        class_weight=self.class_weights,
-                        callbacks=checkpointer,
-                        validation_data=(test_images, test_labels),
-                        initial_epoch=initial_epoch)
-
-            # Evaluate  model
-            score = self.model.evaluate(test_images, test_labels, verbose=0)
-            if verbose:
-                print('Final test loss:', score[0])
-                print('Final test accuracy:', score[1])
-
+        if cv is None:
             # Save model, weights, history
-            if save_model:
-                split_str = save_model.split('.')
-                self.model.save('{}/{}_{}.{}'.format(output_dir,
-                                                     split_str[0], i,
-                                                     split_str[-1]))
-            if save_weights:
-                split_str = save_weights.split('.')
-                self.model.save_weights('{}/{}_{}.{}'.format(output_dir,
-                                                             split_str[0],
-                                                             i, split_str[-1]))
-            if save_history:
-                split_str = save_history.split('.')
-                hist_vals = np.array([hist.history['acc'],
-                                      hist.history['val_acc'],
-                                      hist.history['loss'],
-                                      hist.history['val_loss']])
-                np.savetxt('{}/{}_{}.{}'.format(output_dir,
-                                                split_str[0], i,
-                                                split_str[-1]),
-                           np.transpose(hist_vals),
-                           delimiter=',',
-                           header='acc,val_acc,loss,val_loss')
+            self._fit(train_images, train_labels,
+                      test_images=test_images, test_labels=test_labels,
+                      check_point=check_point,
+                      save_model=save_model,
+                      save_weights=save_weights,
+                      save_history=save_history, **args)
+        else:
+            # Split into testing and training sets
+            if isinstance(cv, int):
+                skf = StratifiedKFold(n_splits=cv, shuffle=shuffle,
+                                      random_state=seed)
+                splitter = skf.split(train_images, train_labels)
+            elif isinstance(cv, BaseCrossValidator):
+                splitter = cv.split(train_images, train_labels)
+            else:
+                raise TypeError('cv must be an integer or an instance of '
+                                'sklearn.model_selection.BaseCrossValidator')
 
-            self.model.set_weights(init_weights)
+            # Store initial weights
+            init_weights = self.model.get_weights()
 
-        self.train_indices = np.asarray(self.train_indices)
-        self.test_indices = np.asarray(self.test_indices)
+            train_indices, test_indices = [], []
+            for fold_idx, (train_index, test_index) in enumerate(splitter):
+                if verbose:
+                    print('Training fold number {}'.format(fold_idx))
+                # Get testing and training split for this fold
+                train_images_fold = train_images[train_index]
+                test_images_fold = train_images[test_index]
+                train_labels_fold = train_labels[train_index]
+                test_labels_fold = train_labels[test_index]
+
+                train_indices.append(train_index)
+                test_indices.append(test_index)
+
+                # Setup model, weights, and history output files
+                check_outfile = None
+                model_outfile = None
+                weights_outfile = None
+                history_outfile = None
+                if save_model:
+                    model_outfile = _get_cv_outfile(save_model, fold_idx)
+                if save_weights:
+                    weights_outfile = _get_cv_outfile(save_weights, fold_idx)
+                if save_history:
+                    history_outfile = _get_cv_outfile(save_history, fold_idx)
+                if check_point:
+                    check_outfile = _get_cv_outfile(check_point, fold_idx)
+
+                self.model.set_weights(init_weights)
+                self._fit(train_images_fold, train_labels_fold,
+                          test_images=test_images_fold,
+                          test_labels=test_labels_fold,
+                          check_point=check_outfile,
+                          save_model=model_outfile,
+                          save_weights=weights_outfile,
+                          save_history=history_outfile,
+                          **args)
+
+            self.train_indices = np.asarray(train_indices)
+            self.test_indices = np.asarray(test_indices)
 
         return self
+
+
+def _get_cv_outfile(file_path, fold_idx):
+    head, tail = os.path.split(file_path)
+    root, ext = os.path.splitext(tail)
+    file_path_fold = os.path.join(head, '{}_{}{}'.format(root, fold_idx, ext))
+    return file_path_fold
+
+
+def _check_shape(x, y):
+    """Checks that x and y are have consistent shapes.
+
+    Casts x and y to numpy.ndarrays, using numpy.asarray, and checks that
+    x and y have the same number of samples (i.e. x.shape[0] == y.shape[0])
+
+    Parameters
+    ----------
+    x : array_like
+        First input array.
+    y : array_like
+        Second input array.
+
+    Returns
+    -------
+    x : numpy.ndarray
+        Numpy array version of x.
+    y : numpy.ndarray
+        Numpy array version of y.
+    """
+    x = np.asarray(x)
+    y = np.asarray(y)
+
+    if not x.shape[0] == y.shape[0]:
+        raise ValueError('Input arrays have shape mismatch')
+
+    return x, y

--- a/decotools/tests/test_convnet.py
+++ b/decotools/tests/test_convnet.py
@@ -1,30 +1,61 @@
 
 import pytest
+import os
 import numpy as np
 
+import keras
+from keras.models import Sequential
+from keras.layers import Conv2D, MaxPooling2D, Cropping2D
+from keras.layers import Flatten, Dense, Dropout
+from keras.layers.advanced_activations import LeakyReLU
+from keras.constraints import maxnorm
+
 from decotools.convnet import (CNN, get_brightest_pixel, get_crop_range,
-                               process_image_files)
+                               process_image_files, _get_cv_outfile,
+                               _check_shape)
 from decotools.tests.utils import save_test_images
 
 
-default_cnn = CNN()
-training_cnn = CNN(training=True)
-
 np.random.seed(2)
+
+# Construct data set for running tests
+n_classes = 4
 
 n_training = 10
 train_images = np.random.random((n_training, 100, 100, 1))
-train_labels = np.random.randint(2, size=n_training)
+train_labels = np.random.randint(n_classes, size=n_training)
 
 n_testing = 10
 test_images = np.random.random((n_testing, 100, 100, 1))
-test_labels = np.random.randint(2, size=n_testing)
+test_labels = np.random.randint(n_classes, size=n_testing)
+
+# Construct simplified model to speed up testing
+model = Sequential()
+model.add(Cropping2D(cropping=18, input_shape=(100, 100, 1)))
+model.add(Dropout(0.2))
+model.add(Conv2D(16, (3, 3), padding='same'))
+model.add(LeakyReLU(alpha=0.3))
+model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dropout(0.2))
+
+model.add(Flatten())
+model.add(Dense(16, kernel_constraint=maxnorm(3)))
+model.add(LeakyReLU(alpha=0.3))
+model.add(Dropout(0.4))
+model.add(Dense(n_classes, activation='softmax'))
+model.compile(loss=keras.losses.categorical_crossentropy,
+              optimizer=keras.optimizers.Adadelta(),
+              metrics=['accuracy'])
+
+cnn = CNN(custom_model=model)
+training_cnn = CNN(training=True, custom_model=model)
+default_cnn = CNN(training=True)
 
 
 def test_CNN_load_model_fails():
     with pytest.raises(IOError) as excinfo:
         model_file = '/this/file/does/not/exist.h5'
-        default_cnn._load_model(model_file)
+        cnn._load_model(model_file)
     error = 'No model file found for {}...'.format(model_file)
     assert error == str(excinfo.value)
 
@@ -32,7 +63,7 @@ def test_CNN_load_model_fails():
 def test_CNN_load_weights_fails():
     with pytest.raises(IOError) as excinfo:
         weights_file = '/this/file/does/not/exist.h5'
-        default_cnn._load_weights(weights_file)
+        cnn._load_weights(weights_file)
     error = 'No weights file found for {}...'.format(weights_file)
     assert error == str(excinfo.value)
 
@@ -41,19 +72,20 @@ def test_CNN_smooth_labels_fails():
     with pytest.raises(ValueError) as excinfo:
         smooth_factor = 2
         y = [[0, 1], [3, 3]]
-        default_cnn._smooth_labels(y, smooth_factor=smooth_factor)
+        cnn._smooth_labels(y, smooth_factor=smooth_factor)
     error = 'Invalid label smoothing factor: {}'.format(smooth_factor)
     assert error == str(excinfo.value)
 
 
 def test_CNN_fit_passes():
-    training_cnn.fit(train_images, train_labels, test_images, test_labels,
-                     epochs=1, batch_size=n_training)
+    default_cnn.fit(train_images, train_labels,
+                    test_images=test_images, test_labels=test_labels,
+                    epochs=1, batch_size=n_training)
 
 
-def test_CNN_fit_with_kfold_passes():
-    training_cnn.fit_with_kfold(train_images, train_labels, epochs=1,
-                                batch_size=1, k_folds=2)
+def test_CNN_fit_CV_passes():
+    training_cnn.fit(train_images, train_labels,
+                     epochs=1, batch_size=1, cv=2)
 
 
 def test_CNN_fit_batchsize_raises():
@@ -65,31 +97,12 @@ def test_CNN_fit_batchsize_raises():
     assert error == str(excinfo.value)
 
 
-def test_CNN_fit_with_kfold_batchsize_raises():
-    with pytest.raises(ValueError) as excinfo:
-        training_cnn.fit_with_kfold(train_images, train_labels,
-                                    test_images, test_labels,
-                                    batch_size=n_training+1)
-    error = 'batch_size must be <= the number of training images'
-    assert error == str(excinfo.value)
-
-
 def test_CNN_fit_train_samples_raises():
     with pytest.raises(ValueError) as excinfo:
         training_cnn.fit(train_images[:-1], train_labels,
                          test_images, test_labels,
-                         batch_size=n_training+1)
-    error = ('The number of training labels does not match '
-             'the number of training images')
-    assert error == str(excinfo.value)
-
-
-def test_CNN_fit_with_kfold_train_samples_raises():
-    with pytest.raises(ValueError) as excinfo:
-        training_cnn.fit_with_kfold(train_images[:-1], train_labels,
-                                    batch_size=n_training+1)
-    error = ('The number of training labels does not match '
-             'the number of training images')
+                         batch_size=n_training)
+    error = 'Input arrays have shape mismatch'
     assert error == str(excinfo.value)
 
 
@@ -97,10 +110,61 @@ def test_CNN_fit_test_samples_raises():
     with pytest.raises(ValueError) as excinfo:
         training_cnn.fit(train_images, train_labels,
                          test_images[:-1], test_labels,
-                         batch_size=n_training+1)
-    error = ('The number of testing labels does not match '
-             'the number of testing images')
+                         batch_size=n_training)
+    error = 'Input arrays have shape mismatch'
     assert error == str(excinfo.value)
+
+
+def test_CNN_fit_cv_test_images_raises():
+    with pytest.raises(ValueError) as excinfo:
+        training_cnn.fit(train_images, train_labels,
+                         test_images=test_images, test_labels=test_labels,
+                         batch_size=1, cv=2)
+    error = ('Cross-validation fitting and an explicitly '
+             'given testing set can\'t be used at the '
+             'same time')
+    assert error == str(excinfo.value)
+
+
+def test_CNN_output_files(tmpdir):
+    check_point = str(tmpdir.join('best_checkpointed_model.h5'))
+    model_outfile = str(tmpdir.join('my_model.h5'))
+    weights_outfile = str(tmpdir.join('my_weights.h5'))
+    history_outfile = str(tmpdir.join('my_history.npy'))
+
+    training_cnn.fit(train_images, train_labels,
+                     test_images, test_labels,
+                     epochs=1, batch_size=n_training,
+                     check_point=check_point,
+                     save_model=model_outfile,
+                     save_weights=weights_outfile,
+                     save_history=history_outfile)
+    for f in [check_point, model_outfile, weights_outfile, history_outfile]:
+        # Check that output file exists
+        assert os.path.exists(f)
+        # Check that output file isn't empty
+        assert os.path.getsize(f) > 0
+
+
+def test_CNN_cv_output_files(tmpdir):
+    cv = 2
+    check_point = str(tmpdir.join('best_checkpointed_model.h5'))
+    model_outfile = str(tmpdir.join('my_model.h5'))
+    weights_outfile = str(tmpdir.join('my_weights.h5'))
+    history_outfile = str(tmpdir.join('my_history.npy'))
+    training_cnn.fit(train_images, train_labels,
+                     epochs=1, batch_size=1, cv=cv,
+                     check_point=check_point,
+                     save_model=model_outfile,
+                     save_weights=weights_outfile,
+                     save_history=history_outfile)
+    for f in [check_point, model_outfile, weights_outfile, history_outfile]:
+        for fold_idx in range(cv):
+            cv_outfile = _get_cv_outfile(f, fold_idx)
+            # Check that output file exists
+            assert os.path.exists(cv_outfile)
+            # Check that output file isn't empty
+            assert os.path.getsize(cv_outfile) > 0
 
 
 def test_get_brightest_pixel():
@@ -141,3 +205,18 @@ def test_process_image_files_shape(tmpdir):
                                               return_edge_filter=True)
     test_shape = (edge_filter.sum(), 2*size, 2*size, 1)
     np.testing.assert_array_equal(images.shape, test_shape)
+
+
+def test_get_cv_outfile():
+    file_path = '/path/to/my_saved_model.h5'
+    fold_idx = 2
+    cv_outfile = _get_cv_outfile(file_path, fold_idx)
+    assert cv_outfile == '/path/to/my_saved_model_{}.h5'.format(fold_idx)
+
+
+def test_check_shape():
+    x = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]
+    y = [1, 2, 3, 4, 5]
+    x_checked, y_checked = _check_shape(x, y)
+    np.testing.assert_array_equal(x, x_checked)
+    np.testing.assert_array_equal(y, y_checked)


### PR DESCRIPTION
Fixes #63

This PR moves the cross-validation training functionality currently in the `CNN.fit_with_kfold` method into the `fit` method. 