### PR TITLE
Adds tables to default requirements

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 numpy==1.13.0
 pandas
+tables
 scikit-image
 Pillow
 matplotlib


### PR DESCRIPTION
Fixes #65. Adds PyTables to decotools default requirements. 