### PR TITLE
Adds 3.7-dev and nightly python to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ python:
     - "2.7"
     - "3.6"
     - "3.6-dev"
+    - "3.7-dev"
+    - "nightly"
+matrix:
+    fast_finish: true
+    allow_failures:
+        - python: "3.6-dev"
+        - python: "3.7-dev"
+        - python: "nightly"
 env:
   global:
     - KERAS_BACKEND=theano


### PR DESCRIPTION
Adds 3.7-dev and nightly python to travis tests. However, all the dev versions of python are added to the `allow_failures` section (some of the `decotools` dependencies may not be ready for e.g. 3.7 yet). 