### PR TITLE
Switch to tensorflow backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ matrix:
         - python: "3.6-dev"
         - python: "3.7-dev"
         - python: "nightly"
-env:
-  global:
-    - KERAS_BACKEND=theano
 install:
-    - pip install .
+    - pip install .[tf]
     - pip install -r requirements/docs.txt
     - pip install -r requirements/test.txt
 script:

--- a/README.md
+++ b/README.md
@@ -8,19 +8,23 @@ A set of tools to help make DECO life easier :sparkles:
 
 ## Installation
 
-The `decotools` Python package can be installed directly from GitHub via
+The `decotools` Python package can be installed directly from GitHub. `decotools` is built on [Google's Tensorflow](https://www.tensorflow.org/), which must be installed to use `decotools`. If `tensorflow` is already installed, then `decotools` can be installed from GitHub via
 
 ```bash
 $ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools
 ```
 
-`decotools` uses the Theano backend within the [Keras deep learning library](https://keras.io/). To configure this backend, the `KERAS_BACKEND` environment variable should be set to `theano`. For example,
+Alternatively, if `tensorflow` is _not_ installed, then the following commands can be used to install `tensorflow` along with `decotools`.
 
+For installing the CPU version of `tensorflow`:
 ```bash
-export KERAS_BACKEND=theano
+$ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools[tf]
 ```
 
-For more information on Keras backends see https://keras.io/backend/
+For installing the GPU version of `tensorflow`:
+```bash
+$ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools[tf-gpu]
+```
 
 ## Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,21 +45,25 @@ Installation
 ============
 
 
-The latest version of decotools, can be install directly from GitHub using ``pip``
+The ``decotools`` Python package can be installed directly from GitHub. ``decotools`` is built on `Google's Tensorflow <https://www.tensorflow.org/>`_, which must be installed to use ``decotools``. If ``tensorflow`` is already installed, then ``decotools`` can be installed from GitHub via
 
 .. code-block:: bash
 
     $ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools
 
+Alternatively, if ``tensorflow`` is not installed, then the following commands can be used to install ``tensorflow`` along with ``decotools``.
 
-Decotools uses the Theano backend within the `Keras deep learning library <https://keras.io/>`_. To configure this backend, the ``KERAS_BACKEND`` environment variable should be set to ``theano``. For example,
+For installing the CPU version of ``tensorflow``:
 
 .. code-block:: bash
 
-    export KERAS_BACKEND=theano
+    $ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools[tf]
 
+For installing the GPU version of ``tensorflow``:
 
-For more information on Keras backends see https://keras.io/backend/
+.. code-block:: bash
+
+    $ pip install git+https://github.com/WIPACrepo/decotools#egg=decotools[tf-gpu]
 
 
 Indices and tables

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy==1.13.0
+numpy
 pandas
 tables
 scikit-image
@@ -6,6 +6,5 @@ Pillow
 matplotlib
 dask[complete]
 keras
-Theano==0.9
 scikit-learn
 h5py

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ VERSION = decotools.__version__
 with open('requirements/default.txt') as fid:
     INSTALL_REQUIRES = [l.strip() for l in fid.readlines() if l]
 
+EXTRAS_REQUIRE = {
+    'tf': ['tensorflow'],
+    'tf-gpu': ['tensorflow-gpu'],
+}
+
 setup(
     name=DISTNAME,
     version=VERSION,
@@ -35,5 +40,6 @@ setup(
     author=MAINTAINER,
     license=LICENSE,
     packages=find_packages(),
-    install_requires=INSTALL_REQUIRES
+    install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE
 )


### PR DESCRIPTION
Fixes #68.

This PR switch the keras backend used by decotools from Theano to tensorflow 